### PR TITLE
Integrate Traccar REST API for tracker assignment and real-time vehicle location

### DIFF
--- a/app/controllers/api/v1/traccar_controller.rb
+++ b/app/controllers/api/v1/traccar_controller.rb
@@ -1,0 +1,108 @@
+class Api::V1::TraccarController < Api::V1::BaseController
+  before_action :set_vehicle, only: [ :assign_tracker, :position ]
+
+  # GET /api/v1/traccar/devices
+  # Lists all devices registered in Traccar so the client can pick one to assign.
+  def devices
+    traccar_devices = traccar_service.devices
+    render_success({ devices: traccar_devices })
+  rescue TraccarApiService::TraccarError => e
+    render_error(e.message, :service_unavailable)
+  end
+
+  # POST /api/v1/traccar/vehicles/:vehicle_id/assign_tracker
+  # Body: { traccar_id: <integer>, name: <string (optional)> }
+  #
+  # Finds or creates a Device record for this vehicle linked to the given Traccar
+  # device ID, then renames the device in Traccar to the vehicle's registration
+  # number so both systems stay in sync.
+  def assign_tracker
+    traccar_id = params.require(:traccar_id).to_i
+
+    # Verify the Traccar device exists before touching local records
+    traccar_device = traccar_service.device(traccar_id)
+
+    device = @vehicle.devices.find_or_initialize_by(traccar_id: traccar_id)
+    device.name   = params[:name].presence || traccar_device['name']
+    device.status = 'active'
+
+    if device.save
+      traccar_service.update_device(traccar_id, name: @vehicle.registration_number)
+      render_success({ device: serialize_device(device) }, 'Tracker assigned to vehicle')
+    else
+      render_error('Failed to assign tracker', :unprocessable_entity, device.errors)
+    end
+  rescue TraccarApiService::NotFoundError
+    render_error('Traccar device not found', :not_found)
+  rescue TraccarApiService::AuthenticationError => e
+    render_error(e.message, :unauthorized)
+  rescue TraccarApiService::TraccarError => e
+    render_error(e.message, :service_unavailable)
+  end
+
+  # GET /api/v1/traccar/vehicles/:vehicle_id/position
+  # Returns the latest Traccar position for the vehicle's linked tracker.
+  # Optional param: ?traccar_id=<id> to target a specific device on the vehicle.
+  def position
+    device = resolve_traccar_device
+
+    unless device
+      return render_error('No Traccar device linked to this vehicle', :not_found)
+    end
+
+    positions = traccar_service.positions(device_id: device.traccar_id)
+    latest    = Array(positions).first
+
+    unless latest
+      return render_error('No position data available for this device', :not_found)
+    end
+
+    render_success({
+      vehicle_id: @vehicle.id,
+      registration_number: @vehicle.registration_number,
+      traccar_device_id: device.traccar_id,
+      position: {
+        latitude:    latest['latitude'],
+        longitude:   latest['longitude'],
+        speed:       latest['speed'],
+        course:      latest['course'],
+        altitude:    latest['altitude'],
+        accuracy:    latest['accuracy'],
+        address:     latest['address'],
+        recorded_at: latest['deviceTime']
+      }
+    })
+  rescue TraccarApiService::TraccarError => e
+    render_error(e.message, :service_unavailable)
+  end
+
+  private
+
+  def set_vehicle
+    @vehicle = Vehicle.find(params[:vehicle_id])
+  end
+
+  def traccar_service
+    @traccar_service ||= TraccarApiService.new
+  end
+
+  def resolve_traccar_device
+    if params[:traccar_id].present?
+      @vehicle.devices.find_by(traccar_id: params[:traccar_id].to_i)
+    else
+      @vehicle.devices.where.not(traccar_id: nil).order(updated_at: :desc).first
+    end
+  end
+
+  def serialize_device(device)
+    {
+      id:          device.id,
+      traccar_id:  device.traccar_id,
+      name:        device.name,
+      status:      device.status,
+      vehicle_id:  device.vehicle_id,
+      terminal_id: device.terminal_id,
+      sim_number:  device.sim_number
+    }
+  end
+end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,6 +1,9 @@
 class Device < ApplicationRecord
   belongs_to :vehicle
 
+  scope :with_traccar, -> { where.not(traccar_id: nil) }
+  validates :traccar_id, uniqueness: true, allow_nil: true
+
   def online?
     return true if status == "online"
     return false unless last_heartbeat_at

--- a/app/services/traccar_api_service.rb
+++ b/app/services/traccar_api_service.rb
@@ -1,0 +1,76 @@
+class TraccarApiService
+  class TraccarError < StandardError; end
+  class AuthenticationError < TraccarError; end
+  class NotFoundError < TraccarError; end
+
+  include HTTParty
+  base_uri ENV.fetch('TRACCAR_BASE_URL', 'http://178.62.101.24:8000')
+
+  def initialize(email = nil, password = nil)
+    email    ||= ENV.fetch('TRACCAR_EMAIL', 'admin')
+    password ||= ENV.fetch('TRACCAR_PASSWORD', 'admin')
+    @auth = { basic_auth: { username: email, password: password } }
+  end
+
+  # List all devices registered in Traccar
+  def devices
+    response = self.class.get('/api/devices', @auth)
+    handle_response(response)
+  end
+
+  # Fetch a single Traccar device by its Traccar ID
+  def device(traccar_id)
+    response = self.class.get("/api/devices/#{traccar_id}", @auth)
+    handle_response(response)
+  end
+
+  # Latest position(s) — pass device_id to scope to one device
+  def positions(device_id: nil)
+    opts = @auth.dup
+    opts[:query] = { deviceId: device_id } if device_id
+    response = self.class.get('/api/positions', opts)
+    handle_response(response)
+  end
+
+  # Update mutable fields on a Traccar device (name, groupId, etc.)
+  # Traccar requires the full device object on PUT, so we fetch first.
+  def update_device(traccar_id, attributes)
+    current = device(traccar_id)
+    return nil unless current.is_a?(Hash)
+
+    body = current.merge(attributes.stringify_keys)
+    response = self.class.put(
+      "/api/devices/#{traccar_id}",
+      @auth.merge(body: body.to_json, headers: { 'Content-Type' => 'application/json' })
+    )
+    handle_response(response)
+  end
+
+  # Link a Traccar device to a Traccar driver via the permissions endpoint
+  def link_driver(traccar_device_id, traccar_driver_id)
+    response = self.class.post(
+      '/api/permissions',
+      @auth.merge(body: { deviceId: traccar_device_id, driverId: traccar_driver_id }.to_json,
+                  headers: { 'Content-Type' => 'application/json' })
+    )
+    handle_response(response)
+  end
+
+  private
+
+  def handle_response(response)
+    case response.code
+    when 200, 201, 204
+      response.parsed_response
+    when 401
+      raise AuthenticationError, 'Invalid Traccar credentials'
+    when 404
+      raise NotFoundError, 'Traccar resource not found'
+    else
+      raise TraccarError, "Traccar API error #{response.code}: #{response.message}"
+    end
+  rescue HTTParty::Error, Timeout::Error, Errno::ECONNREFUSED => e
+    Rails.logger.error("Traccar connection error: #{e.message}")
+    raise TraccarError, "Traccar server unavailable: #{e.message}"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,6 +176,11 @@ Rails.application.routes.draw do
         end
       end
 
+      # Traccar GPS integration
+      get  'traccar/devices',                                    to: 'traccar#devices'
+      post 'traccar/vehicles/:vehicle_id/assign_tracker',        to: 'traccar#assign_tracker'
+      get  'traccar/vehicles/:vehicle_id/position',              to: 'traccar#position'
+
       # Notifications
       resources :notifications, only: [ :index, :show, :update ] do
         member do

--- a/db/migrate/20260427000001_add_traccar_id_to_devices.rb
+++ b/db/migrate/20260427000001_add_traccar_id_to_devices.rb
@@ -1,0 +1,6 @@
+class AddTraccarIdToDevices < ActiveRecord::Migration[8.0]
+  def change
+    add_column :devices, :traccar_id, :integer
+    add_index :devices, :traccar_id, unique: true
+  end
+end


### PR DESCRIPTION
## Summary

- **TraccarApiService** — HTTParty service wrapping the Traccar REST API (`/api/devices`, `/api/positions`, `/api/permissions`, device `PUT`). Credentials are read from `TRACCAR_BASE_URL`, `TRACCAR_EMAIL`, and `TRACCAR_PASSWORD` ENV vars (defaults match the prod server at `http://178.62.101.24:8000`).
- **Api::V1::TraccarController** — three JWT-authenticated API endpoints:
  - `GET /api/v1/traccar/devices` — lists all devices registered in Traccar so the client can present a picker
  - `POST /api/v1/traccar/vehicles/:vehicle_id/assign_tracker` — links a Traccar device to a vehicle (creates/updates the local `Device` record with `traccar_id`, and back-fills the vehicle registration number into Traccar for cross-reference)
  - `GET /api/v1/traccar/vehicles/:vehicle_id/position` — returns the latest lat/lng/speed/course/altitude from Traccar for the vehicle's linked tracker; supports `?traccar_id=` to target a specific device
- **Migration** (`20260427000001`) — adds `traccar_id :integer` with a unique index to `devices`
- **Device model** — adds `scope :with_traccar` and `validates :traccar_id, uniqueness: true, allow_nil: true`

## Reviewer notes

- `assign_tracker` fetches the Traccar device before touching local records, so it returns 404 cleanly if the caller passes a non-existent Traccar ID.
- `update_device` does a GET-then-PUT (Traccar requires the full object on PUT), so one extra round-trip happens on assignment — intentional to avoid blanking existing Traccar fields.
- The existing JT808 TCP pipeline (port 6808) is unchanged; this adds a parallel REST path for Traccar-managed devices.

## Test plan

- [ ] Run `bin/rails db:migrate` and verify `traccar_id` column appears on `devices`
- [ ] Set `TRACCAR_BASE_URL`, `TRACCAR_EMAIL`, `TRACCAR_PASSWORD` in `.env`
- [ ] `GET /api/v1/traccar/devices` returns the device list from Traccar
- [ ] `POST /api/v1/traccar/vehicles/:id/assign_tracker` with `{ traccar_id: <id> }` creates a Device record and updates the name in Traccar
- [ ] `GET /api/v1/traccar/vehicles/:id/position` returns a position hash for a vehicle with an assigned tracker
- [ ] Passing an invalid `traccar_id` returns 404

Generated with [Claude Code](https://claude.com/claude-code)
