### PR TITLE
Add Capistrano for SSH-based auto deployment to production

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,30 @@
+# Load DSL and set up stages
+require "capistrano/setup"
+
+# Include default deployment tasks
+require "capistrano/deploy"
+
+# Load the SCM plugin appropriate to your project:
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+
+# Bundler
+require "capistrano/bundler"
+
+# Rails tasks (assets, migrations)
+require "capistrano/rails/assets"
+require "capistrano/rails/migrations"
+
+# rbenv
+require "capistrano/rbenv"
+
+# Puma
+require "capistrano/puma"
+install_plugin Capistrano::Puma
+install_plugin Capistrano::Puma::Systemd
+
+# Yarn (JS bundling)
+require "capistrano/yarn"
+
+# Load custom tasks from `lib/capistrano/tasks` if you create any, e.g.:
+# Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -79,4 +79,12 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  # Deployment
+  gem "capistrano",                  "~> 3.18", require: false
+  gem "capistrano-rails",            "~> 1.6",  require: false
+  gem "capistrano-bundler",          "~> 2.1",  require: false
+  gem "capistrano-rbenv",            "~> 2.2",  require: false
+  gem "capistrano3-puma",            "~> 6.0",  require: false
+  gem "capistrano-yarn",                        require: false
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,92 @@
+# config/deploy.rb — shared deployment configuration
+
+set :application, "fleet_core_engine"
+set :repo_url,    "https://github.com/kiburei/fleet_core_engine.git"
+
+# Deploy from the main branch by default; override per stage
+set :branch, ENV.fetch("BRANCH", "main")
+
+# Deploy to /var/www/fleet_core_engine on the server
+set :deploy_to, "/var/www/fleet_core_engine"
+
+# Keep the last 5 releases
+set :keep_releases, 5
+
+# Linked files are symlinked into each release from the shared/ directory
+append :linked_files,
+  "config/master.key",
+  "config/credentials.yml.enc",
+  ".env"
+
+# Linked directories are symlinked into each release from shared/
+append :linked_dirs,
+  "log",
+  "tmp/pids",
+  "tmp/cache",
+  "tmp/sockets",
+  "public/uploads",
+  "storage"
+
+# rbenv — must match the Ruby version on the server
+set :rbenv_type,       :system          # :user if rbenv is installed per-user
+set :rbenv_ruby,       File.read(".ruby-version").strip rescue "3.3.0"
+set :rbenv_prefix,     "RBENV_ROOT=/usr/local/rbenv RBENV_VERSION=#{fetch(:rbenv_ruby)} /usr/local/rbenv/bin/rbenv exec"
+set :rbenv_path,       "/usr/local/rbenv"
+
+# Bundler
+set :bundle_without,   %w[development test]
+set :bundle_flags,     "--deployment --quiet"
+
+# Assets (propshaft + jsbundling)
+set :assets_roles, [:web]
+
+# Puma
+set :puma_bind,        "tcp://0.0.0.0:3000"
+set :puma_state,       "#{shared_path}/tmp/pids/puma.state"
+set :puma_pid,         "#{shared_path}/tmp/pids/puma.pid"
+set :puma_access_log,  "#{release_path}/log/puma.access.log"
+set :puma_error_log,   "#{release_path}/log/puma.error.log"
+set :puma_threads,     [0, 5]
+set :puma_workers,     2
+set :puma_worker_timeout, nil
+set :puma_init_active_record, true
+
+# Output format
+set :format,        :airbrussh
+set :format_options, command_output: true, log_file: "log/capistrano.log", color: :auto, truncate: :auto
+
+# Default value for :pty is false
+set :pty, false
+
+# Git clone options
+set :git_shallow_clone, 1
+
+# Run migrations only when DB files changed
+set :migration_role, :db
+
+namespace :deploy do
+  desc "Restart application (touch tmp/restart.txt for Puma plugin, or reload systemd service)"
+  task :restart do
+    on roles(:web), in: :sequence, wait: 5 do
+      execute :touch, release_path.join("tmp/restart.txt")
+    end
+  end
+
+  desc "Seed the database"
+  task :seed do
+    on roles(:db) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, "db:seed"
+        end
+      end
+    end
+  end
+
+  after :publishing, :restart
+  after :restart,    :clear_cache do
+    on roles(:web), in: :groups, limit: 3, wait: 10 do
+      # execute :rake, "tmp:clear" if you want to clear tmp on each deploy
+    end
+  end
+end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,0 +1,12 @@
+# config/deploy/production.rb
+
+server "178.62.101.24",
+  user:  "deploy",
+  roles: %w[web app db],
+  ssh_options: {
+    keys:            %w[~/.ssh/id_rsa],
+    forward_agent:   true,
+    auth_methods:    %w[publickey]
+  }
+
+set :rails_env, "production"

--- a/docs/CAPISTRANO_DEPLOYMENT.md
+++ b/docs/CAPISTRANO_DEPLOYMENT.md
@@ -1,0 +1,187 @@
+# Capistrano Deployment Guide
+
+## Prerequisites
+
+### Local machine
+```bash
+bundle install
+```
+
+### Server setup (one-time, as root on 178.62.101.24)
+
+**1. Create deploy user**
+```bash
+adduser deploy
+usermod -aG sudo deploy
+# Allow deploy to reload/restart puma service without password
+echo "deploy ALL=(ALL) NOPASSWD: /bin/systemctl restart fleet_core_engine, /bin/systemctl reload fleet_core_engine, /bin/systemctl start fleet_core_engine, /bin/systemctl stop fleet_core_engine" >> /etc/sudoers.d/deploy
+```
+
+**2. Add your SSH public key**
+```bash
+su - deploy
+mkdir -p ~/.ssh && chmod 700 ~/.ssh
+echo "<your-public-key>" >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+```
+
+**3. Install rbenv + Ruby 3.3.0**
+```bash
+su - deploy
+git clone https://github.com/rbenv/rbenv.git /usr/local/rbenv
+git clone https://github.com/rbenv/ruby-build.git /usr/local/rbenv/plugins/ruby-build
+echo 'export RBENV_ROOT=/usr/local/rbenv' >> /etc/profile.d/rbenv.sh
+echo 'export PATH="$RBENV_ROOT/bin:$PATH"' >> /etc/profile.d/rbenv.sh
+echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh
+source /etc/profile.d/rbenv.sh
+rbenv install 3.3.0
+rbenv global 3.3.0
+gem install bundler
+```
+
+**4. Install Node.js + Yarn**
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+sudo npm install -g yarn
+```
+
+**5. Install system packages**
+```bash
+sudo apt-get install -y git nginx redis-server sqlite3 libsqlite3-dev \
+  libpq-dev build-essential libssl-dev libreadline-dev zlib1g-dev
+```
+
+**6. Create deploy directory**
+```bash
+sudo mkdir -p /var/www/fleet_core_engine
+sudo chown deploy:deploy /var/www/fleet_core_engine
+```
+
+**7. Create shared files**
+```bash
+su - deploy
+mkdir -p /var/www/fleet_core_engine/shared/config
+mkdir -p /var/www/fleet_core_engine/shared/log
+mkdir -p /var/www/fleet_core_engine/shared/tmp/{pids,cache,sockets}
+mkdir -p /var/www/fleet_core_engine/shared/storage
+mkdir -p /var/www/fleet_core_engine/shared/public/uploads
+
+# Copy master.key from local to server
+scp config/master.key deploy@178.62.101.24:/var/www/fleet_core_engine/shared/config/master.key
+scp config/credentials.yml.enc deploy@178.62.101.24:/var/www/fleet_core_engine/shared/config/credentials.yml.enc
+
+# Create .env on server
+touch /var/www/fleet_core_engine/shared/.env
+# Edit it with your production env vars: DATABASE_URL, REDIS_URL, etc.
+```
+
+**8. Nginx reverse proxy (port 3000 → 80)**
+
+`/etc/nginx/sites-available/fleet_core_engine`:
+```nginx
+upstream fleet_puma {
+  server 127.0.0.1:3000;
+}
+
+server {
+  listen 80;
+  server_name 178.62.101.24 fleet.matean.online;
+
+  root /var/www/fleet_core_engine/current/public;
+
+  location ^~ /assets/ {
+    gzip_static on;
+    expires max;
+    add_header Cache-Control public;
+  }
+
+  location / {
+    try_files $uri @puma;
+  }
+
+  location @puma {
+    proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header  Host $http_host;
+    proxy_set_header  X-Forwarded-Proto $scheme;
+    proxy_redirect    off;
+    proxy_pass        http://fleet_puma;
+  }
+
+  error_page 500 502 503 504 /500.html;
+  client_max_body_size 10M;
+  keepalive_timeout 10;
+}
+```
+
+```bash
+sudo ln -s /etc/nginx/sites-available/fleet_core_engine /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+**9. Puma systemd service**
+
+`/etc/systemd/system/fleet_core_engine.service`:
+```ini
+[Unit]
+Description=Fleet Core Engine Puma Server
+After=network.target
+
+[Service]
+Type=simple
+User=deploy
+WorkingDirectory=/var/www/fleet_core_engine/current
+ExecStart=/usr/local/rbenv/bin/rbenv exec bundle exec puma -C config/puma.rb
+ExecReload=/bin/kill -SIGUSR2 $MAINPID
+KillMode=process
+Restart=on-failure
+RestartSec=5
+Environment=RAILS_ENV=production
+Environment=PORT=3000
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl enable fleet_core_engine
+sudo systemctl start fleet_core_engine
+```
+
+---
+
+## First deploy
+
+```bash
+# Check connectivity and directory structure
+bundle exec cap production deploy:check
+
+# Full deploy
+bundle exec cap production deploy
+```
+
+## Subsequent deploys
+
+```bash
+bundle exec cap production deploy
+```
+
+## Useful tasks
+
+```bash
+# Deploy a specific branch
+BRANCH=feature/my-branch bundle exec cap production deploy
+
+# Run migrations only
+bundle exec cap production deploy:migrate
+
+# Rollback
+bundle exec cap production deploy:rollback
+
+# Restart Puma
+bundle exec cap production puma:restart
+
+# Tail logs
+bundle exec cap production deploy:log_revision
+ssh deploy@178.62.101.24 tail -f /var/www/fleet_core_engine/current/log/production.log
+```


### PR DESCRIPTION
## Summary

- Adds Capistrano 3 gems to the `development` group (`capistrano`, `capistrano-rails`, `capistrano-bundler`, `capistrano-rbenv`, `capistrano3-puma`, `capistrano-yarn`)
- Creates `Capfile` loading all required plugins (git SCM, bundler, assets, migrations, rbenv, puma systemd, yarn)
- Creates `config/deploy.rb` with shared config: app name, repo URL, 5-release retention, linked files/dirs, Puma bound to port 3000
- Creates `config/deploy/production.rb` targeting server `178.62.101.24` with `deploy` user
- Adds `docs/CAPISTRANO_DEPLOYMENT.md` with full server setup walkthrough (deploy user, rbenv, Nginx reverse proxy, Puma systemd service) and common deploy commands

## What changed and why

The project previously had only Kamal (Docker-based) deployment config. This adds traditional Capistrano-based deployment for direct SSH deploys to the existing server at `178.62.101.24` running Rails on port 3000.

## Reviewer notes

- **Deploy user**: `config/deploy/production.rb` uses `user: "deploy"` — change to `"root"` if the server is currently only set up for root SSH access.
- **rbenv path**: Set to `/usr/local/rbenv` (system-wide install). Update `rbenv_path` in `config/deploy.rb` if rbenv is installed per-user under `~/.rbenv`.
- **Linked files**: `shared/.env`, `shared/config/master.key`, and `shared/config/credentials.yml.enc` must be created on the server before the first `cap production deploy:check`.
- **First deploy**: Run `bundle exec cap production deploy:check` first to verify server directory structure, then `bundle exec cap production deploy`.

## Test plan

- [ ] `bundle install` succeeds with new Capistrano gems
- [ ] Server `deploy` user created and SSH key authorised
- [ ] `bundle exec cap production deploy:check` passes
- [ ] `bundle exec cap production deploy` completes and app is reachable at `http://178.62.101.24:3000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)